### PR TITLE
host-binutils: depends on host-texinfo

### DIFF
--- a/package/binutils/binutils.mk
+++ b/package/binutils/binutils.mk
@@ -54,7 +54,7 @@ HOST_BINUTILS_CONF_OPT = --disable-multilib --disable-werror \
 			--with-sysroot=$(STAGING_DIR) \
 			$(BINUTILS_EXTRA_CONFIG_OPTIONS)
 
-HOST_BINUTILS_DEPENDENCIES =
+HOST_BINUTILS_DEPENDENCIES = host-texinfo
 
 # We just want libbfd and libiberty, not the full-blown binutils in staging
 define BINUTILS_INSTALL_STAGING_CMDS


### PR DESCRIPTION
We need Buildroot to install the host-texinfo package otherwise the
texinfo package available in the host machine may be too new and will
cause build failures like this one:

bfd.texinfo:325: unknown command `colophon'
bfd.texinfo:336: unknown command`cygnus'
make[3]: **\* [bfd.info] Error 1

Signed-off-by: Vicente Olivert Riera Vincent.Riera@imgtec.com
